### PR TITLE
Make Multisite Compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/db.php
+++ b/db.php
@@ -1,5 +1,28 @@
 <?php
 
-if ( file_exists( WP_CONTENT_DIR . '/plugins/facetwp-cache/cache.php' ) ) {
-    include( WP_CONTENT_DIR . '/plugins/facetwp-cache/cache.php' );
+if ( is_multisite() ) {
+
+	//* Delay loading cache.php if multisite to allow for correct population of $table_prefix
+	add_action( 'ms_loaded', 'fwp_load_cache_file' );
+
+} else {
+
+	//* Load cache.php
+	fwp_load_cache_file();
+
+}
+
+/**
+ * Load plugin's cache.php file
+ *
+ * @return void
+ */
+function fwp_load_cache_file() {
+
+	if ( file_exists( WP_CONTENT_DIR . '/plugins/facetwp-cache/cache.php' ) ) {
+
+		include( WP_CONTENT_DIR . '/plugins/facetwp-cache/cache.php' );
+
+	}
+
 }

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: FacetWP - Cache
 Description: Caching support for FacetWP
-Version: 1.3.2
+Version: 1.4.0
 Author: FacetWP, LLC
 Author URI: https://facetwp.com/
 GitHub URI: facetwp/facetwp-cache
@@ -19,7 +19,7 @@ class FacetWP_Cache
     function __construct() {
 
         // setup variables
-        define( 'FACETWP_CACHE_VERSION', '1.3.2' );
+        define( 'FACETWP_CACHE_VERSION', '1.4.0' );
         define( 'FACETWP_CACHE_DIR', dirname( __FILE__ ) );
 
         add_action( 'init' , array( $this, 'init' ) );


### PR DESCRIPTION
On multisite `cache.php` was being loaded too early resulting in the base prefix ( wp_ ) being used to set `$table_prefix`.  Delaying loading `cache.php` until `ms-settings.php` has loaded on multisite appears to fix the issue.  